### PR TITLE
Allow Middleware.enabled to override the mode

### DIFF
--- a/lib/stackprof/middleware.rb
+++ b/lib/stackprof/middleware.rb
@@ -15,8 +15,8 @@ module StackProf
     end
 
     def call(env)
-      enabled = Middleware.enabled?
-      StackProf.start(mode: Middleware.mode, interval: Middleware.interval) if enabled
+      enabled, mode = Middleware.enabled?
+      StackProf.start(mode: mode || Middleware.mode, interval: Middleware.interval) if enabled
       @app.call(env)
     ensure
       if enabled

--- a/test/test_middleware.rb
+++ b/test/test_middleware.rb
@@ -46,4 +46,18 @@ class StackProf::MiddlewareTest < Test::Unit::TestCase
     assert StackProf::Middleware.enabled?
   end
 
+  def test_enabled_should_override_mode_if_a_proc
+    proc_called = false
+    middleware = StackProf::Middleware.new(proc {|env| proc_called = true}, enabled: Proc.new{ [true, 'foo'] })
+    enabled, mode = StackProf::Middleware.enabled?
+    assert enabled
+    assert_equal 'foo', mode
+
+    StackProf.expects(:start).with({mode: 'foo', interval: StackProf::Middleware.interval})
+    StackProf.expects(:stop)
+
+    middleware.call(nil)
+    assert proc_called
+  end
+
 end


### PR DESCRIPTION
Middleware.enabled should be able to override the default mode, if it is a proc.

@camilo for review.
